### PR TITLE
Fix multiple dependent fields

### DIFF
--- a/lib/ppx/Meta.re
+++ b/lib/ppx/Meta.re
@@ -664,7 +664,7 @@ module InputTypeParser = {
                  UnvalidatedDepField({name: dep}),
                  UnvalidatedDepField({name: dep'}),
                ) =>
-               dep == dep
+               dep == dep'
              | (
                  UnvalidatedDepFieldOfCollection({collection, field}),
                  UnvalidatedDepFieldOfCollection({

--- a/lib/test/Test.re
+++ b/lib/test/Test.re
@@ -24,6 +24,7 @@ let () =
             "Ok__FieldWithSyncValidatorAndFieldWithAsyncValidatorInOnChangeMode",
             "Ok__FieldWithSyncValidatorAndFieldWithAsyncValidatorInOnBlurMode",
             "Ok__FieldWithSyncValidatorAndDependentFieldAndFieldWithSyncValidator",
+            "Ok__FieldWithSyncValidatorAndTwoDependentFieldsWithSyncValidators",
             "Ok__TwoFieldsWithNoValidators",
             "Ok__TwoFieldsWithSyncValidators",
             "Ok__TwoFieldsWithAsyncValidatorsInOnChangeMode",

--- a/lib/test/cases/Ok__FieldWithSyncValidatorAndTwoDependentFieldsWithSyncValidators.re
+++ b/lib/test/cases/Ok__FieldWithSyncValidatorAndTwoDependentFieldsWithSyncValidators.re
@@ -1,0 +1,21 @@
+module Form = [%form
+  type input = {
+    a: [@field.deps (b, c)] string,
+    b: string,
+    c: string,
+  };
+  let validators = {
+    a: {
+      strategy: OnSubmit,
+      validate: ({a, _}) => Ok(a),
+    },
+    b: {
+      strategy: OnSubmit,
+      validate: ({b, _}) => Ok(b),
+    },
+    c: {
+      strategy: OnSubmit,
+      validate: ({c, _}) => Ok(c),
+    },
+  }
+];


### PR DESCRIPTION
This was the initial error the new test produced.
```
  We've found a bug for you!
  ./test/cases/Ok__FieldWithSyncValidatorAndTwoDependentFieldsWithSyncValidators.re:3:25
  
  1 │ module Form = [%form
  2 │   type input = {
  3 │     a: [@field.deps (b, c)] string,
  4 │     b: string,
  5 │     c: string,
  
  Field `c` is already declared as a dependency for this field

```