### PR TITLE
Add support for m1 through rosetta

### DIFF
--- a/.github/workflows/scripts/postinstall.js
+++ b/.github/workflows/scripts/postinstall.js
@@ -11,6 +11,10 @@ if (arch === "ia32") {
   arch = "x86";
 }
 
+if (arch === "arm64") {
+  arch = "x64";
+}
+
 if (platform === "win32") {
   platform = "win";
 }


### PR DESCRIPTION
On m1 macs the ppx throws an error in postinstall because it cannot find a build for the arm64 architecture, this is a simple fix so that it can run using Rosetta.