### PR TITLE
Field deps documentation updated with correct rescript syntax

### DIFF
--- a/docs/07-DependentFields.md
+++ b/docs/07-DependentFields.md
@@ -3,7 +3,7 @@ If the validity of one field depends on the value of another, use `@field.deps` 
 
 ```reason
 type input = {
-  a: @field.deps (b) string,
+  a: @field.deps(b) string,
   b: string,
 };
 ```
@@ -15,7 +15,7 @@ A real-world use-case is a form that updates a password:
 ```reason
 type input = {
   oldPassword string,
-  newPassword: @field.deps (newPasswordConfirmation) string,
+  newPassword: @field.deps(newPasswordConfirmation) string,
   newPasswordConfirmation: string,
 };
 ```
@@ -26,7 +26,7 @@ If you need to re-validate multiple fields, provide a tuple:
 
 ```reason
 type input = {
-  a: @field.deps ((b, c)) string,
+  a: @field.deps((b, c)) string,
   b: string,
   c: int,
 };

--- a/docs/07-DependentFields.md
+++ b/docs/07-DependentFields.md
@@ -1,9 +1,9 @@
 # Dependent Fields
-If the validity of one field depends on the value of another, use `[@field.deps]` attribute to mark the relation.
+If the validity of one field depends on the value of another, use `@field.deps` attribute to mark the relation.
 
 ```reason
 type input = {
-  a: [@field.deps b] string,
+  a: @field.deps (b) string,
   b: string,
 };
 ```
@@ -15,7 +15,7 @@ A real-world use-case is a form that updates a password:
 ```reason
 type input = {
   oldPassword string,
-  newPassword: [@field.deps newPasswordConfirmation] string,
+  newPassword: @field.deps (newPasswordConfirmation) string,
   newPasswordConfirmation: string,
 };
 ```
@@ -26,7 +26,7 @@ If you need to re-validate multiple fields, provide a tuple:
 
 ```reason
 type input = {
-  a: [@field.deps (b, c)] string,
+  a: @field.deps ((b, c)) string,
   b: string,
   c: int,
 };
@@ -36,8 +36,8 @@ If one of the dependent fields is a field of collection, define it like this:
 
 ```reason
 type input = {
-  title: [@field.deps author.name] string,
-  authors: [@field.collection] array(author),
+  title: @field.deps(author.name) string,
+  authors: @field.collection array<author>,
 }
 and author = {name: string}
 ```


### PR DESCRIPTION
This PR contains an update on field deps documentation with examples having correct rescript syntax. 